### PR TITLE
Add some fixes from @muan

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -12,15 +12,26 @@ botAdder = (arg1, msg) ->
 botifyMessages = =>
   botify($('.message'))
 
+# Botify the currently-viewed channel
+botifyMessages()
+
+# Attach .sent_by_me to messages sent by the current user
+meAdder = (selector) ->
+  selector.each (_, el) ->
+    $(el).addClass 'sent_by_me'
+
+sentByMeMessages = (selector) ->
+  selector = '.message_sender[data-member-id=' + TS.boot_data.user_id + ']'
+  messages = $(selector).closest('ts-message')
+  messages.each (_, el) ->
+    $(el).addClass 'sent_by_me'
+
 TS.groups.message_received_sig.add(botAdder)
 TS.channels.message_received_sig.add(botAdder)
 TS.channels.switched_sig.add botifyMessages
 TS.groups.switched_sig.add botifyMessages
 
-whitelist = [
-  "groups.switched_sig"
-  "groups.history_fetched_sig"
-]
-
-# Botify the currently-viewed channel
-botifyMessages()
+TS.channels.switched_sig.add sentByMeMessages
+TS.groups.switched_sig.add sentByMeMessages
+TS.groups.message_received_sig.add(sentByMeMessages)
+TS.channels.message_received_sig.add(sentByMeMessages)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -59,3 +59,90 @@ ts-message {
 .color_bot_Hubot, .color_bot_hubot {
   display: none !important;
 }
+
+/* Allow long bot message to scroll */
+.bot_label ~ .message_body .dynamic_content_max_width {
+  font-family: menlo;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: auto;
+  max-width: 100%;
+  display: block;
+}
+
+/* Move text expander on its own line */
+.bot_label ~ .message_body .dynamic_content_max_width .rest_text_expander {
+  display: block;
+}
+
+/* Unify timestamp style */
+.timestamp {
+  float: right;
+  font-family: menlo;
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+/* Smaller avatar becasue of the padding changes */
+ts-message .member_image {
+  transform: scale(0.8);
+}
+
+ts-message .message_gutter,
+ts-message .message_gutter a {
+  font-family: menlo;
+  font-size: 11px;
+  text-align: center;
+}
+/* Override hover background (distracting) */
+.message:hover {
+  background: none !important;
+}
+
+/* Move star button becasue of the padding changes */
+.message_star_holder {
+  left: 8px;
+  position: absolute;
+  top: -1px;
+}
+
+/* Smaller emojis to go with smaller text */
+.emoji-outer {
+  transform: scale(0.8);
+}
+
+/* Don't separate bot messages */
+.bot_message + .bot_message {
+  border-top: 0;
+}
+
+#messages_container .message_gutter {
+  padding-left: 20px;
+}
+
+/* Highlight messages sent by current user */
+.sent_by_me {
+  .message_content:before {
+    background: #fff9f0;
+    border-bottom: 1px solid #eee;
+    border-top: 1px solid #eee;
+    content: '';
+    display: block;
+    height: 100%;
+    margin-left: -80px;
+    margin-top: -3px;
+    position: absolute;
+    width: 100%;
+    z-index: -1;
+  }
+
+  ts-message:not(.first) .message_sender{
+    display: block;
+    font-size: 0;
+    margin-bottom: -15px;
+  }
+
+  ts-message:not(.first) .message_sender:before {
+    border-top: 0;
+  }
+}


### PR DESCRIPTION
Brings in a buncha great stuff from @muan:

https://github.com/muan/slack-custom-css/blob/ff3c1a5c47e8696432c6c7755065146f94f62f08/hacks.css

Adds:
- highlighting self-messages
- removes border between hubot messages
- SCROLLING AND AWESOME BT3 OUTPUT AWWWWW YEAH

cc @ross @grantr @technicalpickles
