### PR TITLE
Change input history to be per-room instead of global

### DIFF
--- a/app/assets/javascripts/per-room-history.coffee
+++ b/app/assets/javascripts/per-room-history.coffee
@@ -1,0 +1,71 @@
+existingMessageHistory = localStorage.getItem("per_room_history")
+if existingMessageHistory?
+  try
+    history = JSON.parse(existingMessageHistory)
+    TS.model.per_room_input_history = history
+  catch e
+    console.log "Failed to parse existing history. Moving on with life."
+
+TS.chat_history.initializeChannelHistory = (cid) ->
+  TS.model.per_room_input_history ||= {}
+  history = TS.model.per_room_input_history[TS.model.active_cid]
+  if !history?
+    history = {}
+    history.index = -1
+    history.entries = []
+    TS.model.per_room_input_history[TS.model.active_cid] = history
+
+  return history
+
+TS.chat_history.add = (txt) ->
+  unless TS.model.prefs?.arrow_history
+    return
+  if txt is ""
+    return
+
+  history = TS.chat_history.initializeChannelHistory(TS.model.active_cid)
+
+  entries = history.entries
+
+  index = entries.indexOf(txt)
+  if index != -1
+    entries.splice(index, 1)
+  entries.unshift(txt)
+  entries.splice(30)
+  localStorage.setItem("per_room_history", JSON.stringify(TS.model.per_room_input_history))
+
+TS.chat_history.resetPosition = (why) ->
+  history = TS.chat_history.initializeChannelHistory(TS.model.active_cid)
+  history.index = -1
+
+TS.chat_history.onArrowKey = (e, input) ->
+  unless TS.model.prefs?.arrow_history
+    return
+  history = TS.chat_history.initializeChannelHistory(TS.model.active_cid)
+  return unless history.entries.length
+
+  txt = input.val()
+  hist_text = ""
+  if history.index < 0
+    history.current = txt
+
+  if e.which == TS.utility.keymap.up
+    history.index += 1
+    if history.index >= history.entries.length
+      history.index = history.entries.length - 1
+      return
+  else if e.which == TS.utility.keymap.down
+    history.index -= 1
+    if history.index < 0
+      history.index = -1
+      hist_text = history.current
+  else
+    return
+
+  hist_text ||= history.entries[history.index]
+  e.preventDefault()
+  TS.utility.populateInput(TS.client.ui.$msg_input, hist_text)
+  if e.which == TS.utility.keymap.up
+    input.setCursorPosition 0
+  else
+    input.setCursorPosition(input.val().length)


### PR DESCRIPTION
Changes slack's problematic all-rooms-share-a-history behavior to each-room-has-its-own-history. I've kept the other quirks of the up-arrow behavior, in particular 'when you press up the cursor goes to the beginning of the line, but if you past a line and come back down, it goes to the end'. This has confused me several times but I'm rolling with it for now, because I like my javascript wild and zany.

This is already live for anyone in #slack-hacks; this PR is just a place to for me to cc @muan @scottjg and @jakeboxer, who mentioned this on twitter: https://twitter.com/muanchiou/status/695402435267801091

cc also @dvillega @jwietelmann 

I'm not reading work slack or email til after Mardi Gras, so tweet at me if this breaks something.
