### PR TITLE
Bash style input editing

### DIFF
--- a/app/assets/javascripts/console-ish-input.coffee
+++ b/app/assets/javascripts/console-ish-input.coffee
@@ -13,3 +13,17 @@ input.bind "keydown", (e) ->
     TS.chat_history.onArrowKey(e, input)
     input.setCursorPosition(input.val().length)
     e.preventDefault()
+
+input.bind "keydown", (e) ->
+  # ctrl-w
+  return unless e.ctrlKey == true and e.keyCode == 87
+
+  currentIndex = input.getCursorPosition()
+  currentValue = input.val()
+  beforeCurrent = currentValue.substring(0, currentIndex)
+
+  previousWhitespaceIndex = beforeCurrent.lastIndexOf(" ")
+  previousWhitespaceIndex = 0 if previousWhitespaceIndex == -1
+  valueWithWordRemoved = currentValue.slice(0, previousWhitespaceIndex) + currentValue.slice(currentIndex)
+  input.val(valueWithWordRemoved)
+  input.setCursorPosition(previousWhitespaceIndex)

--- a/app/assets/javascripts/console-ish-input.coffee
+++ b/app/assets/javascripts/console-ish-input.coffee
@@ -27,3 +27,21 @@ input.bind "keydown", (e) ->
   valueWithWordRemoved = currentValue.slice(0, previousWhitespaceIndex) + currentValue.slice(currentIndex)
   input.val(valueWithWordRemoved)
   input.setCursorPosition(previousWhitespaceIndex)
+
+input.bind "keydown", (e) ->
+  # ctrl-k
+  return unless e.ctrlKey == true and e.keyCode == 75
+
+  currentIndex = input.getCursorPosition()
+  currentValue = input.val()
+  input.val(currentValue.slice(0, currentIndex))
+  input.setCursorPosition(currentIndex)
+
+input.bind "keydown", (e) ->
+  # ctrl-u
+  return unless e.ctrlKey == true and e.keyCode == 85
+
+  currentIndex = input.getCursorPosition()
+  currentValue = input.val()
+  input.val(currentValue.slice(currentIndex))
+  input.setCursorPosition(0)

--- a/app/assets/javascripts/console-ish-input.coffee
+++ b/app/assets/javascripts/console-ish-input.coffee
@@ -1,0 +1,15 @@
+input = TS.client.ui.$msg_input
+
+# by default slack won't go to previous commands with 'up', just to the front
+# of the line. Fix that if there's no newlines in the message.
+input.bind "keydown", (e) ->
+  return if input.val().indexOf("\n") != -1
+
+  if (e.which == TS.utility.keymap.up && input.getCursorPosition() >= 1)
+    TS.chat_history.onArrowKey(e, input)
+    input.setCursorPosition(input.val().length)
+    e.preventDefault()
+  else if (e.which == TS.utility.keymap.down && input.getCursorPosition() < input.val().length)
+    TS.chat_history.onArrowKey(e, input)
+    input.setCursorPosition(input.val().length)
+    e.preventDefault()

--- a/app/assets/javascripts/per-room-history.coffee
+++ b/app/assets/javascripts/per-room-history.coffee
@@ -65,7 +65,4 @@ TS.chat_history.onArrowKey = (e, input) ->
   hist_text ||= history.entries[history.index]
   e.preventDefault()
   TS.utility.populateInput(TS.client.ui.$msg_input, hist_text)
-  if e.which == TS.utility.keymap.up
-    input.setCursorPosition 0
-  else
-    input.setCursorPosition(input.val().length)
+  input.setCursorPosition(input.val().length)


### PR DESCRIPTION
Adds ctrl-k, ctrl-w, and ctrl-u. 

In an effort to make this more console-ish, the cursor will now always be at the end of the prompt when you go up in history.

cc @jssjr
