### PR TITLE
Scrolling weirdness take 2

### DIFF
--- a/app/assets/javascripts/main.coffee
+++ b/app/assets/javascripts/main.coffee
@@ -36,6 +36,23 @@ removeTinyImageGarbage = ->
   $('.file_preview_preserve_aspect_ratio').each (_, el) ->
     $(el).css('width','').css('height','')
 
+slackBuildImgDiv = TS.templates.builders.buildInlineImgDiv
+TS.templates.builders.buildInlineImgDiv = (args...) ->
+  result = slackBuildImgDiv(args...)
+  width = result.match(/data-width="(\d+)"/)[1]
+  max_width = TS.client.ui.$msgs_div.width() - 156
+
+  height = result.match(/data-height="(\d+)"/)[1]
+  max_height = if max_width >= width
+                height
+              else
+                (max_width / width) * height
+
+  result = result.replace(/<div class="file_preview_preserve_aspect_ratio" style="width: \d+px; height: \d+px;">/,
+                          "<div class=\"file_preview_preserve_aspect_ratio\" style=\"width: #{max_width}px; height: #{max_height}px;\">")
+  result
+
+
 redraw = ->
   botifyMessages()
   sentByMeMessages()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,9 +61,6 @@ ts-message {
   padding-bottom: 0px;
 }
 
-.msg_inline_img_holder .msg_inline_img_container {
-  max-width: inherit;
-}
 .attachment_group {
   max-width: inherit;
   margin: 0;


### PR DESCRIPTION
Instead of fighting slack on hardcoding width/height, fight slack on hardcoding a different, bigger width/height.

This still isn't enough, but forcing a redraw before `instaScrollMessagesToBottom` seems to do the trick. I can't replicate any strangeness on this one. Here goes nothing.
